### PR TITLE
👽 adapts DDVis to the latest changes from mqt-core

### DIFF
--- a/cpp/module/QDDVer.cpp
+++ b/cpp/module/QDDVer.cpp
@@ -64,8 +64,8 @@ void QDDVer::stepForward(bool algo1) {
   if (algo1) {
     if (atEnd1)
       return; // no further steps possible
-    const auto currDD =
-        dd::getDD(iterator1->get(), dd); // retrieve the "new" current operation
+    const auto currDD = dd::getDD(iterator1->get(),
+                                  *dd); // retrieve the "new" current operation
 
     auto temp = dd->multiply(
         currDD, sim); // process the current operation by multiplying it with
@@ -86,7 +86,7 @@ void QDDVer::stepForward(bool algo1) {
       return; // no further steps possible
     const auto currDD = dd::getInverseDD(
         iterator2->get(),
-        dd); // retrieve the inverse of the "new" current operation
+        *dd); // retrieve the inverse of the "new" current operation
 
     auto temp = dd->multiply(
         sim, currDD); // process the current operation by multiplying it with
@@ -127,7 +127,7 @@ void QDDVer::stepBack(bool algo1) {
     position1--;
 
     const auto currDD = dd::getInverseDD(
-        iterator1->get(), dd); // get the inverse of the current operation
+        iterator1->get(), *dd); // get the inverse of the current operation
 
     auto temp = dd->multiply(
         currDD,
@@ -150,7 +150,7 @@ void QDDVer::stepBack(bool algo1) {
     position2--;
 
     const auto currDD =
-        dd::getDD(iterator2->get(), dd); // get the current operation
+        dd::getDD(iterator2->get(), *dd); // get the current operation
 
     auto temp = dd->multiply(sim, currDD); //"remove" the current operation by
                                            // multiplying with its inverse
@@ -257,7 +257,7 @@ Napi::Value QDDVer::Load(const Napi::CallbackInfo& info) {
         static_cast<unsigned int>(info[1].As<Napi::Number>());
     qc::Format format;
     if (formatCode == 1)
-      format = qc::Format::OpenQASM;
+      format = qc::Format::OpenQASM3;
     else if (formatCode == 2)
       format = qc::Format::Real;
     else {
@@ -310,9 +310,9 @@ Napi::Value QDDVer::Load(const Napi::CallbackInfo& info) {
   if (sim.p == nullptr || (algo1 && !ready2) || (!algo1 && !ready1)) {
     // sim = dd->makeZeroState(qc->getNqubits());
     if (algo1)
-      sim = dd->createInitialMatrix(qc1->getNqubits(), qc1->ancillary);
+      sim = dd->createInitialMatrix(qc1->ancillary);
     else
-      sim = dd->createInitialMatrix(qc2->getNqubits(), qc2->ancillary);
+      sim = dd->createInitialMatrix(qc2->ancillary);
     dd->incRef(sim);
 
   } else { // reset the previously loaded algorithm if process is true

--- a/cpp/module/QDDVis.cpp
+++ b/cpp/module/QDDVis.cpp
@@ -74,13 +74,13 @@ void QDDVis::stepForward() {
 
     if (value == expectedValue) {
       currDD = dd::getDD(iterator->get(),
-                         dd); // retrieve the "new" current operation
+                         *dd); // retrieve the "new" current operation
     } else {
-      currDD = dd->makeIdent(qc->getNqubits());
+      currDD = dd->makeIdent();
     }
   } else {
     currDD =
-        dd::getDD(iterator->get(), dd); // retrieve the "new" current operation
+        dd::getDD(iterator->get(), *dd); // retrieve the "new" current operation
   }
 
   auto temp =
@@ -130,14 +130,15 @@ void QDDVis::stepBack() {
     }
 
     if (value == expectedValue) {
-      currDD = dd::getInverseDD(iterator->get(),
-                                dd); // get the inverse of the current operation
+      currDD =
+          dd::getInverseDD(iterator->get(),
+                           *dd); // get the inverse of the current operation
     } else {
-      currDD = dd->makeIdent(qc->getNqubits());
+      currDD = dd->makeIdent();
     }
   } else {
     currDD = dd::getInverseDD(iterator->get(),
-                              dd); // get the inverse of the current operation
+                              *dd); // get the inverse of the current operation
   }
 
   auto temp = dd->multiply(
@@ -214,7 +215,7 @@ Napi::Value QDDVis::Load(const Napi::CallbackInfo& info) {
     const auto formatCode =
         static_cast<unsigned int>(info[1].As<Napi::Number>());
     if (formatCode == 1)
-      qc->import(ss, qc::Format::OpenQASM);
+      qc->import(ss, qc::Format::OpenQASM3);
     else if (formatCode == 2)
       qc->import(ss, qc::Format::Real);
     else {
@@ -894,8 +895,8 @@ QDDVis::ConductIrreversibleOperation(const Napi::CallbackInfo& info) {
     } else if (classicalValueToMeasure == "1") {
       dd->performCollapsingMeasurement(sim, qubit, pone, false);
       // apply x operation to reset to |0>
-      const auto x   = qc::StandardOperation(qc->getNqubits(), qubit, qc::X);
-      auto       tmp = dd->multiply(dd::getDD(&x, dd), sim);
+      const auto x   = qc::StandardOperation(qubit, qc::X);
+      auto       tmp = dd->multiply(dd::getDD(&x, *dd), sim);
       dd->incRef(tmp);
       dd->decRef(sim);
       sim = tmp;


### PR DESCRIPTION
This PR adjusts DDVis to all the changes that happened in mqt-core. First and foremost, this includes the removal of identity nodes from matrix DDs, which allowed to simplify quite some code in mqt-core.
Additionally, this also brings in a couple of improvements from the OpenQASM 3.0 parser.

Incidentally, this also fixes #258 because it brings in https://github.com/cda-tum/mqt-core/pull/526