### PR TITLE
🐛 Fix error reporting

### DIFF
--- a/cpp/module/QDDVer.cpp
+++ b/cpp/module/QDDVer.cpp
@@ -296,12 +296,10 @@ Napi::Value QDDVer::Load(const Napi::CallbackInfo& info) {
     }
     // resize the DD package so that it can manage the current circuit size
     dd->resize(qc1->getNqubits());
-  } catch (std::exception& e) {
-    std::cout << "Exception while loading the algorithm: " << e.what()
-              << std::endl;
-    std::string err(e.what());
-    Napi::Error::New(env, "Invalid algorithm!\n" + err)
-        .ThrowAsJavaScriptException();
+  } catch (const std::exception& e) {
+    const auto* msg = e.what();
+    std::cout << "Exception while loading the algorithm: " << msg << "\n";
+    Napi::Error::New(env, std::string(msg)).ThrowAsJavaScriptException();
     return state;
   }
 
@@ -322,7 +320,7 @@ Napi::Value QDDVer::Load(const Napi::CallbackInfo& info) {
           stepToStart(true);
         else if (!algo1 && ready2)
           stepToStart(false);
-      } catch (std::exception& e) {
+      } catch (const std::exception& e) {
         std::cout << "Exception while resetting algo" << (algo1 ? "1" : "2")
                   << e.what() << std::endl;
         std::string err(e.what());
@@ -457,7 +455,7 @@ Napi::Value QDDVer::ToStart(const Napi::CallbackInfo& info) {
     stepToStart(algo1);
     return Napi::Boolean::New(env, true); // something changed
 
-  } catch (std::exception& e) {
+  } catch (const std::exception& e) {
     std::cout << "Exception while going back to the start!" << std::endl;
     std::cout << e.what() << std::endl;
     return Napi::Boolean::New(env, false); // nothing changed
@@ -526,7 +524,7 @@ Napi::Value QDDVer::Prev(const Napi::CallbackInfo& info) {
 
     return state;
 
-  } catch (std::exception& e) {
+  } catch (const std::exception& e) {
     std::cout << "Exception while getting the current operation {src: prev}!"
               << e.what() << std::endl;
     std::cout << e.what() << std::endl;
@@ -601,7 +599,7 @@ Napi::Value QDDVer::Next(const Napi::CallbackInfo& info) {
     }
     return state;
 
-  } catch (std::exception& e) {
+  } catch (const std::exception& e) {
     std::cout << "Exception while getting the current operation {src: next}!"
               << std::endl;
     std::cout << e.what() << std::endl;
@@ -686,7 +684,7 @@ Napi::Value QDDVer::ToEnd(const Napi::CallbackInfo& info) {
     state.Set("nops", Napi::Number::New(env, static_cast<double>(nops)));
     return state;
 
-  } catch (std::exception& e) {
+  } catch (const std::exception& e) {
     std::cout << "Exception while going to the end!" << std::endl;
     std::cout << e.what() << std::endl;
     return state;
@@ -776,17 +774,12 @@ Napi::Value QDDVer::ToLine(const Napi::CallbackInfo& info) {
 
     return Napi::Boolean::New(env, true); // something changed
 
-  } catch (std::exception& e) {
-    std::string msg =
-        "Exception while going to line "; // + position + " to " + targetPos;
-    // msg += position + " to " + targetPos;
-    // msg.append(position);
-    // msg.append(" to ");
-    // msg.append(targetPos);
-    std::cout << "Exception while going from "
-              << (algo1 ? position1 : position2) << " to " << targetPos
-              << std::endl;
-    std::cout << e.what() << std::endl;
+  } catch (const std::exception& e) {
+    std::stringstream ss{};
+    ss << "Exception while going from " << (algo1 ? position1 : position2)
+       << " to " << targetPos << ": " << e.what() << "\n";
+    const auto msg = ss.str();
+    std::cout << msg << std::endl;
     Napi::Error::New(env, msg).ThrowAsJavaScriptException();
     return Napi::Boolean::New(env, false);
   }
@@ -816,12 +809,13 @@ Napi::Value QDDVer::GetDD(const Napi::CallbackInfo& info) {
     state.Set("amplitudes", Napi::Float32Array::New(env, 0));
     return state;
 
-  } catch (std::exception& e) {
-    std::cout << "Exception while getting the DD: " << e.what() << std::endl;
-    std::cout << "The values of the Flags are: " << this->showColors << ", "
-              << this->showEdgeLabels << ", " << this->showClassic << ", "
-              << this->usePolarCoordinates << std::endl;
-    std::string err = "Invalid getDD()-call! "; // + e.what();
+  } catch (const std::exception& e) {
+    std::stringstream sserr{};
+    sserr << "Exception while getting the DD: " << e.what() << "\n";
+    sserr << "The values of the Flags are: " << this->showColors << ", "
+          << this->showEdgeLabels << ", " << this->showClassic << ", "
+          << this->usePolarCoordinates << "\n";
+    const auto err = sserr.str();
     Napi::Error::New(env, err).ThrowAsJavaScriptException();
     return Napi::String::New(env, "-1");
   }

--- a/cpp/module/QDDVis.cpp
+++ b/cpp/module/QDDVis.cpp
@@ -224,12 +224,10 @@ Napi::Value QDDVis::Load(const Napi::CallbackInfo& info) {
       return state;
     }
 
-  } catch (std::exception& e) {
-    std::cout << "Exception while loading the algorithm: " << e.what()
-              << std::endl;
-    std::string err(e.what());
-    Napi::Error::New(env, "Invalid algorithm!\n" + err)
-        .ThrowAsJavaScriptException();
+  } catch (const std::exception& e) {
+    const auto* msg = e.what();
+    std::cout << "Exception while loading the algorithm: " << msg << "\n";
+    Napi::Error::New(env, std::string(msg)).ThrowAsJavaScriptException();
     return state;
   }
 
@@ -334,7 +332,7 @@ Napi::Value QDDVis::ToStart(const Napi::CallbackInfo& info) {
 
       return Napi::Boolean::New(env, true); // something changed
 
-    } catch (std::exception& e) {
+    } catch (const std::exception& e) {
       std::cout << "Exception while going back to the start!" << std::endl;
       std::cout << e.what() << std::endl;
       return Napi::Boolean::New(env, false); // nothing changed
@@ -388,7 +386,7 @@ Napi::Value QDDVis::Prev(const Napi::CallbackInfo& info) {
 
     return state; // something changed
 
-  } catch (std::exception& e) {
+  } catch (const std::exception& e) {
     std::cout << "Exception while getting the current operation {src: prev}!"
               << std::endl;
     std::cout << e.what() << std::endl;
@@ -494,7 +492,7 @@ Napi::Value QDDVis::Next(const Napi::CallbackInfo& info) {
       state.Set("nextIsIrreversible", Napi::Boolean::New(env, true));
     }
     return state;
-  } catch (std::exception& e) {
+  } catch (const std::exception& e) {
     std::cout << "Exception while getting the current operation {src: next}!"
               << std::endl;
     std::cout << e.what() << std::endl;
@@ -555,7 +553,7 @@ Napi::Value QDDVis::ToEnd(const Napi::CallbackInfo& info) {
       }
       state.Set("nops", Napi::Number::New(env, static_cast<double>(nops)));
       return state;
-    } catch (std::exception& e) {
+    } catch (const std::exception& e) {
       std::cout << "Exception while going to the end!" << std::endl;
       std::cout << e.what() << std::endl;
       return state;
@@ -680,16 +678,12 @@ Napi::Value QDDVis::ToLine(const Napi::CallbackInfo& info) {
 
     return state; // something changed
 
-  } catch (std::exception& e) {
-    std::string msg =
-        "Exception while going to line "; // + position + " to " + targetPos;
-    // msg += position + " to " + targetPos;
-    // msg.append(position);
-    // msg.append(" to ");
-    // msg.append(targetPos);
-    std::cout << "Exception while going from " << position << " to "
-              << targetPos << std::endl;
-    std::cout << e.what() << std::endl;
+  } catch (const std::exception& e) {
+    std::stringstream ss{};
+    ss << "Exception while going from " << position << " to " << targetPos
+       << ": " << e.what() << "\n";
+    const auto msg = ss.str();
+    std::cout << msg << std::endl;
     Napi::Error::New(env, msg).ThrowAsJavaScriptException();
     return state;
   }
@@ -725,12 +719,13 @@ Napi::Value QDDVis::GetDD(const Napi::CallbackInfo& info) {
     }
     return state;
 
-  } catch (std::exception& e) {
-    std::cout << "Exception while getting the DD: " << e.what() << std::endl;
-    std::cout << "The values of the Flags are: " << this->showColors << ", "
-              << this->showEdgeLabels << ", " << this->showClassic << ", "
-              << this->usePolarCoordinates << std::endl;
-    std::string err = "Invalid getDD()-call! "; // + e.what();
+  } catch (const std::exception& e) {
+    std::stringstream sserr{};
+    sserr << "Exception while getting the DD: " << e.what() << "\n";
+    sserr << "The values of the Flags are: " << this->showColors << ", "
+          << this->showEdgeLabels << ", " << this->showClassic << ", "
+          << this->usePolarCoordinates << "\n";
+    const auto err = sserr.str();
     Napi::Error::New(env, err).ThrowAsJavaScriptException();
     return Napi::String::New(env, "-1");
   }

--- a/public/javascripts/algo_area.js
+++ b/public/javascripts/algo_area.js
@@ -331,48 +331,23 @@ class AlgoArea {
     if (res.responseJSON && res.responseJSON.msg) {
       const parserError = res.responseJSON.msg;
 
-      let lineStart = parserError.indexOf("l:"); //"l:" states the server-side line
-      if (lineStart > -1) {
-        lineStart += 2; //skip "l:"
+      // Extract filename, line, column, and message from the error string
+      const errorParts = parserError.split(/:\s*/);
+      const lineMsg = parseInt(errorParts[1]);
+      const column = parseInt(errorParts[2]);
+      const msg = errorParts[3];
 
-        const lineEnd = parserError.indexOf(":", lineStart);
-        if (lineEnd > -1) {
-          const lineMsg = parseInt(parserError.substring(lineStart, lineEnd)); //the line that is stated
-          // in the parser message
-          const temp = this._line_numbers.html().split("\n");
-          let lineNumber;
-          if (temp.length < lineMsg || lineMsg <= 0) lineNumber = lineMsg;
-          else {
-            lineNumber = parseInt(temp[lineMsg - 1]); //use the number that the line numbering displays
-            //if no line numbers are there yet, we simply display the number from the parser error
-            if (!lineNumber) lineNumber = lineMsg;
-          }
-
-          const line = lineNumber;
-          if (line) {
-            let colStart = parserError.indexOf("c:", lineEnd - 1);
-            if (colStart > -1) {
-              colStart += 2;
-
-              const colEnd = parserError.indexOf("msg:", colStart);
-              if (colEnd > -1) {
-                const column = parseInt(parserError.substr(colStart, colEnd));
-
-                errMsg += "line " + line + ", column " + column + "\n";
-              } else errMsg += "line " + line + "\n";
-            } else errMsg += "line " + line + "\n";
-          }
-        }
+      // Get the line number displayed in the line numbering
+      const temp = this._line_numbers.html().split("\n");
+      let lineNumber;
+      if (temp.length < lineMsg || lineMsg <= 0) lineNumber = lineMsg;
+      else {
+        lineNumber = parseInt(temp[lineMsg - 1]);
+        if (!lineNumber) lineNumber = lineMsg;
       }
 
-      const msgStart = parserError.indexOf("msg:") + 4;
-      if (msgStart > -1) {
-        //don't show the position information of the error, if there is any additionally (because the line is
-        // wrong and we've already created the information)
-        const msgEnd = parserError.lastIndexOf(" in line");
-        if (msgEnd > -1) errMsg += parserError.substring(msgStart, msgEnd);
-        else errMsg += parserError.substring(msgStart);
-      }
+      // Construct the error message
+      errMsg += "line " + lineNumber + ", column " + column + "\n" + msg;
     }
 
     return errMsg;


### PR DESCRIPTION
The new QASM parser in mqt-core brought along new error messages that were not compatible with the way they were handled here. This update corrects for this change and should now allow proper error reporting again.

Fixes #259 