### PR TITLE
🐛 Fix dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
-  "name": "ddvis",
-  "version": "1.6.1",
+  "name": "mqt-ddvis",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "ddvis",
-      "version": "1.6.1",
+      "name": "mqt-ddvis",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "body-parser": "^1.20.2",
         "cmake-js": "^7.3.0",
         "cookie-parser": "^1.4.6",
-        "d3-graphviz": "^5.4.0",
+        "d3-graphviz": "^5.3.0",
         "express": "^4.19.2",
         "http-errors": "^2.0.0",
         "jquery": "^3.7.1",
@@ -371,11 +371,11 @@
       }
     },
     "node_modules/d3-graphviz": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/d3-graphviz/-/d3-graphviz-5.4.0.tgz",
-      "integrity": "sha512-e/kvvdfIfARiB4bF9/vDgY6WwvLxGCny2tS6ozUaOwgbL/CfaBWT7EwvCH5PiDQuvdx+xscnxjCsoUjw2CR86A==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/d3-graphviz/-/d3-graphviz-5.3.0.tgz",
+      "integrity": "sha512-esY291tZsn4NKxnJa1CVsgyc1KFUp1AlZz81GWyJadrM648iEnVpcXeGKqjyXbkLkeI59Dc2YmkuWE07eG+fYw==",
       "dependencies": {
-        "@hpcc-js/wasm": "^2.16.2",
+        "@hpcc-js/wasm": "^2.16.0",
         "d3-dispatch": "^3.0.1",
         "d3-format": "^3.1.0",
         "d3-interpolate": "^3.0.1",
@@ -4159,11 +4159,11 @@
       "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="
     },
     "d3-graphviz": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/d3-graphviz/-/d3-graphviz-5.4.0.tgz",
-      "integrity": "sha512-e/kvvdfIfARiB4bF9/vDgY6WwvLxGCny2tS6ozUaOwgbL/CfaBWT7EwvCH5PiDQuvdx+xscnxjCsoUjw2CR86A==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/d3-graphviz/-/d3-graphviz-5.3.0.tgz",
+      "integrity": "sha512-esY291tZsn4NKxnJa1CVsgyc1KFUp1AlZz81GWyJadrM648iEnVpcXeGKqjyXbkLkeI59Dc2YmkuWE07eG+fYw==",
       "requires": {
-        "@hpcc-js/wasm": "^2.16.2",
+        "@hpcc-js/wasm": "^2.16.0",
         "d3-dispatch": "^3.0.1",
         "d3-format": "^3.1.0",
         "d3-interpolate": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "body-parser": "^1.20.2",
         "cmake-js": "^7.3.0",
         "cookie-parser": "^1.4.6",
-        "d3-graphviz": "^5.3.0",
+        "d3-graphviz": "^5.4.0",
         "express": "^4.19.2",
         "http-errors": "^2.0.0",
         "jquery": "^3.7.1",
@@ -371,11 +371,11 @@
       }
     },
     "node_modules/d3-graphviz": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/d3-graphviz/-/d3-graphviz-5.3.0.tgz",
-      "integrity": "sha512-esY291tZsn4NKxnJa1CVsgyc1KFUp1AlZz81GWyJadrM648iEnVpcXeGKqjyXbkLkeI59Dc2YmkuWE07eG+fYw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/d3-graphviz/-/d3-graphviz-5.4.0.tgz",
+      "integrity": "sha512-e/kvvdfIfARiB4bF9/vDgY6WwvLxGCny2tS6ozUaOwgbL/CfaBWT7EwvCH5PiDQuvdx+xscnxjCsoUjw2CR86A==",
       "dependencies": {
-        "@hpcc-js/wasm": "^2.16.0",
+        "@hpcc-js/wasm": "^2.16.2",
         "d3-dispatch": "^3.0.1",
         "d3-format": "^3.1.0",
         "d3-interpolate": "^3.0.1",
@@ -4159,11 +4159,11 @@
       "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="
     },
     "d3-graphviz": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/d3-graphviz/-/d3-graphviz-5.3.0.tgz",
-      "integrity": "sha512-esY291tZsn4NKxnJa1CVsgyc1KFUp1AlZz81GWyJadrM648iEnVpcXeGKqjyXbkLkeI59Dc2YmkuWE07eG+fYw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/d3-graphviz/-/d3-graphviz-5.4.0.tgz",
+      "integrity": "sha512-e/kvvdfIfARiB4bF9/vDgY6WwvLxGCny2tS6ozUaOwgbL/CfaBWT7EwvCH5PiDQuvdx+xscnxjCsoUjw2CR86A==",
       "requires": {
-        "@hpcc-js/wasm": "^2.16.0",
+        "@hpcc-js/wasm": "^2.16.2",
         "d3-dispatch": "^3.0.1",
         "d3-format": "^3.1.0",
         "d3-interpolate": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "body-parser": "^1.20.2",
     "cmake-js": "^7.3.0",
     "cookie-parser": "^1.4.6",
-    "d3-graphviz": "^5.3.0",
+    "d3-graphviz": "^5.4.0",
     "express": "^4.19.2",
     "http-errors": "^2.0.0",
     "jquery": "^3.7.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "body-parser": "^1.20.2",
     "cmake-js": "^7.3.0",
     "cookie-parser": "^1.4.6",
-    "d3-graphviz": "^5.4.0",
+    "d3-graphviz": "^5.3.0",
     "express": "^4.19.2",
     "http-errors": "^2.0.0",
     "jquery": "^3.7.1",

--- a/public/index.html
+++ b/public/index.html
@@ -78,7 +78,7 @@
     </script>
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <script
-      src="https://unpkg.com/@hpcc-js/wasm/dist/graphviz.umd.js"
+      src="https://unpkg.com/@hpcc-js/wasm@2.16.2/dist/graphviz.umd.js"
       type="javascript/worker"
     ></script>
     <script src="https://unpkg.com/d3-graphviz@5.4.0/build/d3-graphviz.js"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -81,8 +81,7 @@
       src="https://unpkg.com/@hpcc-js/wasm/dist/graphviz.umd.js"
       type="javascript/worker"
     ></script>
-    <script src="https://unpkg.com/d3-graphviz@5.0.2/build/d3-graphviz.js"></script>
-
+    <script src="https://unpkg.com/d3-graphviz@5.4.0/build/d3-graphviz.js"></script>
     <script src="./javascripts/highlighting.js"></script>
     <script src="./javascripts/algo_area.js"></script>
     <script src="./javascripts/main.js"></script>


### PR DESCRIPTION
This fixes a small bug in the DDVis javascript that is due to a third-party update somewhere (probably with `wasm`).
The error was reproducible locally and fixed by this PR.