### PR TITLE
🔧 Reconfigure `prek` priorities

### DIFF
--- a/.license-tools-config.json
+++ b/.license-tools-config.json
@@ -35,6 +35,6 @@
     ".*build.*",
     "Dockerfile",
     ".*\\.webmanifest",
-    "LICENSE"
+    "(^|/)LICENSE$"
   ]
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,8 +14,6 @@ ci:
   autofix_commit_msg: "🎨 pre-commit fixes"
 
 repos:
-  # Priority 0: Fast validation and independent fixers
-
   ## Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -25,7 +23,7 @@ repos:
       - id: end-of-file-fixer
         priority: 1
       - id: trailing-whitespace
-        priority: 1
+        priority: 2
 
   ## Check JSON schemata
   - repo: https://github.com/python-jsonschema/check-jsonschema
@@ -36,7 +34,7 @@ repos:
       - id: check-readthedocs
         priority: 0
 
-  ## Catch common capitalization mistakes
+  ## Check for common capitalization mistakes
   - repo: local
     hooks:
       - id: disallow-caps
@@ -46,21 +44,21 @@ repos:
         exclude: ^(\.pre-commit-config\.yaml)$
         priority: 0
 
-  ## Check for spelling
+  ## Check for typos
   - repo: https://github.com/adhtruong/mirrors-typos
     rev: v1.45.0
     hooks:
       - id: typos
-        priority: 0
+        priority: 3
 
-  ## Check for license headers
+  ## Check license headers
   - repo: https://github.com/emzeat/mz-lictools
     rev: v2.9.0
     hooks:
       - id: license-tools
-        priority: 0
+        priority: 4
 
-  ## Tidy up BibTeX files
+  ## Format BibTeX files with bibtex-tidy
   - repo: https://github.com/FlamingTempura/bibtex-tidy
     rev: v1.14.0
     hooks:
@@ -77,27 +75,7 @@ repos:
             "--trailing-commas",
             "--remove-empty-fields",
           ]
-        priority: 0
-
-  # Priority 1: Second-pass fixers
-
-  ## Clang-format the C++ part of the code base automatically
-  - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v22.1.3
-    hooks:
-      - id: clang-format
-        types_or: [c++, c, cuda]
-        priority: 1
-
-  ## Format the CMakeLists.txt files
-  - repo: https://github.com/cheshirekow/cmake-format-precommit
-    rev: v0.6.13
-    hooks:
-      - id: cmake-format
-        additional_dependencies: [pyyaml]
-        types: [file]
-        files: (\.cmake|CMakeLists.txt)(.in)?$
-        priority: 1
+        priority: 5
 
   ## Format configuration files with prettier
   - repo: https://github.com/rbubley/mirrors-prettier
@@ -105,14 +83,32 @@ repos:
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json, json5]
-        priority: 1
+        priority: 5
 
-  ## Python linting using ruff
+  ## Format CMake files with cmake-format
+  - repo: https://github.com/cheshirekow/cmake-format-precommit
+    rev: v0.6.13
+    hooks:
+      - id: cmake-format
+        additional_dependencies: [pyyaml]
+        types: [file]
+        files: (\.cmake|CMakeLists.txt)(.in)?$
+        priority: 5
+
+  ## Format C++ files with clang-format
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v22.1.3
+    hooks:
+      - id: clang-format
+        types_or: [c++, c, cuda]
+        priority: 5
+
+  ## Format and lint Python files with ruff
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.10
     hooks:
       - id: ruff-format
-        priority: 1
+        priority: 5
       - id: ruff-check
         require_serial: true
-        priority: 2
+        priority: 6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,8 +31,6 @@ repos:
     hooks:
       - id: check-github-workflows
         priority: 0
-      - id: check-readthedocs
-        priority: 0
 
   ## Check for common capitalization mistakes
   - repo: local


### PR DESCRIPTION
## Description

This PR reconfigures the `prek` priorities to ensure that no two hooks write at the same time.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
